### PR TITLE
use opencppcover from program files, add setting to choose executable

### DIFF
--- a/VSPackage/FodyWeavers.xml
+++ b/VSPackage/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers>
+  <PropertyChanged />
+</Weavers>

--- a/VSPackage/OpenCppCoverage.cs
+++ b/VSPackage/OpenCppCoverage.cs
@@ -37,7 +37,7 @@ namespace OpenCppCoverage.VSPackage
         public Task RunCodeCoverageAsync(MainSettings settings)
         {
             var basicSettings = settings.BasicSettings;
-            var fileName = GetOpenCppCoveragePath(basicSettings.ProgramToRun);
+            var fileName = GetOpenCppCoveragePath(basicSettings.ProgramToRun, settings);
             var arguments = OpenCppCoverageCmdLine.Build(settings);
 
             this.outputWindowWriter.WriteLine("Run:");
@@ -63,15 +63,9 @@ namespace OpenCppCoverage.VSPackage
         }
 
         //---------------------------------------------------------------------
-        string GetOpenCppCoveragePath(string commandPath)
+        string GetOpenCppCoveragePath(string commandPath, MainSettings settings)
         {
-            var assemblyLocation = System.Reflection.Assembly.GetExecutingAssembly().Location;
-            var assemblyFolder = Path.GetDirectoryName(assemblyLocation);
-            var openCppCovergeFolder = 
-                Is64bitsExecutable(commandPath) ? 
-                    "OpenCppCoverage-x64" : "OpenCppCoverage-x86";
-
-            return Path.Combine(assemblyFolder, openCppCovergeFolder, "OpenCppCoverage.exe");
+            return settings.MiscellaneousSettings.OpenCppCoverExe;
         }
 
         //---------------------------------------------------------------------

--- a/VSPackage/Settings/MainSettings.cs
+++ b/VSPackage/Settings/MainSettings.cs
@@ -95,5 +95,6 @@ namespace OpenCppCoverage.VSPackage.Settings
         public string OptionalConfigFile { get; set; }
         public LogType LogTypeValue { get; set; }
         public bool ContinueAfterCppExceptions { get; set; }
+        public string OpenCppCoverExe { get; set; }
     }
 }

--- a/VSPackage/Settings/UI/MiscellaneousSettingControl.xaml
+++ b/VSPackage/Settings/UI/MiscellaneousSettingControl.xaml
@@ -24,6 +24,7 @@
                 <RowDefinition Height="auto"/>
                 <RowDefinition Height="auto"/>
                 <RowDefinition Height="auto"/>
+                <RowDefinition Height="auto"/>
             </Grid.RowDefinitions>
             <Label Content="Log verbosity" Grid.Row="0"/>
             <ComboBox 
@@ -46,6 +47,14 @@
                 Grid.Row="1" Grid.Column="2"
                 Margin="0 5 0 5"/>
 
+            <Label Content="OpenCppCover Executable" Grid.Row="4"/>
+            <helper:FileSystemSelectionControl 
+                Mode="FileSelection"
+                FileFilter="OpenCppCoverage (OpenCppCoverage.exe)|OpenCppCoverage.exe"
+                SelectedPath="{Binding OpenCppCoverExe}"
+                Grid.Row="3" Grid.Column="2"
+                Margin="0 5 0 5"/>
+            
             <Label Content="Continue after C++ exceptions" Grid.Row="2"/>
             <CheckBox 
                 IsChecked="{Binding ContinueAfterCppExceptions}" 

--- a/VSPackage/Settings/UI/MiscellaneousSettingController.cs
+++ b/VSPackage/Settings/UI/MiscellaneousSettingController.cs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using OpenCppCoverage.VSPackage.Helper;
+using PropertyChanged;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,6 +23,7 @@ using System.Linq;
 namespace OpenCppCoverage.VSPackage.Settings.UI
 {
     //-------------------------------------------------------------------------
+    [ImplementPropertyChanged]
     class MiscellaneousSettingController: PropertyChangedNotifier
     {
         //---------------------------------------------------------------------
@@ -29,6 +31,8 @@ namespace OpenCppCoverage.VSPackage.Settings.UI
         {
             this.LogTypeValues = Enum.GetValues(typeof(MiscellaneousSettings.LogType))
                 .Cast<MiscellaneousSettings.LogType>();
+
+            this.OpenCppCoverExe = @"C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe";
         }
 
         //---------------------------------------------------------------------
@@ -47,47 +51,27 @@ namespace OpenCppCoverage.VSPackage.Settings.UI
             {
                 OptionalConfigFile = this.OptionalConfigFile,
                 LogTypeValue = this.LogTypeValue,
-                ContinueAfterCppExceptions = this.ContinueAfterCppExceptions
+                ContinueAfterCppExceptions = this.ContinueAfterCppExceptions,
+                OpenCppCoverExe = this.OpenCppCoverExe
             };
         }
 
         //---------------------------------------------------------------------
-        bool hasConfigFile;
-        public bool HasConfigFile
-        {
-            get { return this.hasConfigFile; }
-            set
-            {
-                if (this.SetField(ref this.hasConfigFile, value) && !value)
-                    this.OptionalConfigFile = null;
-            }
-        }
+        public bool HasConfigFile { get; set; }
 
         //---------------------------------------------------------------------
-        string optionalConfigFile;
-        public string OptionalConfigFile
-        {
-            get { return this.optionalConfigFile; }
-            set { this.SetField(ref this.optionalConfigFile, value); }
-        }
+        public string OptionalConfigFile { get; set; }
 
         //---------------------------------------------------------------------
-        MiscellaneousSettings.LogType logTypeValue;
-        public MiscellaneousSettings.LogType LogTypeValue
-        {
-            get { return this.logTypeValue; }
-            set { this.SetField(ref this.logTypeValue, value); }
-        }
+        public MiscellaneousSettings.LogType LogTypeValue { get; set; }
 
         //---------------------------------------------------------------------
-        bool continueAfterCppExceptions;
-        public bool ContinueAfterCppExceptions
-        {
-            get { return this.continueAfterCppExceptions; }
-            set { this.SetField(ref this.continueAfterCppExceptions, value); }
-        }
-        
-        //---------------------------------------------------------------------        
-        public IEnumerable<MiscellaneousSettings.LogType> LogTypeValues { get; private set; }        
+        public bool ContinueAfterCppExceptions { get; set; }
+
+        //---------------------------------------------------------------------
+        public string OpenCppCoverExe { get; set; }
+
+        //---------------------------------------------------------------------
+        public IEnumerable<MiscellaneousSettings.LogType> LogTypeValues { get; private set; }
     }
 }

--- a/VSPackage/VSPackage.csproj
+++ b/VSPackage/VSPackage.csproj
@@ -9,6 +9,8 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>12.0</OldToolsVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -84,6 +86,10 @@
     <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="PropertyChanged, Version=1.52.1.0, Culture=neutral, PublicKeyToken=ee3ee20bcf148ddd, processorArchitecture=MSIL">
+      <HintPath>..\packages\PropertyChanged.Fody.1.52.1\lib\netstandard10\PropertyChanged.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
@@ -247,6 +253,7 @@
     <None Include="Resources\Images.png" />
   </ItemGroup>
   <ItemGroup>
+    <Resource Include="FodyWeavers.xml" />
     <Content Include="gpl-3.0.txt">
       <IncludeInVSIX>true</IncludeInVSIX>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -263,193 +270,7 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="OpenCppCoverage-x64\boost_chrono-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_date_time-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_filesystem-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_locale-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_log-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_program_options-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_regex-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_system-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_thread-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\CppCoverage.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Exporter.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\libctemplate.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\OpenCppCoverage.exe">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\MainTemplate.html">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\SourceTemplate.html">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\css\style.css">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\css\table-images\botleft.png">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\css\table-images\botright.png">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\css\table-images\left.png">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\css\table-images\right.png">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\google-code-prettify\prettify-CppCoverage.css">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\google-code-prettify\prettify.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\google-code-prettify\run_prettify.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\JQuery\jquery-1.11.1.min.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\RGraph\libraries\RGraph.common.core.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\RGraph\libraries\RGraph.common.dynamic.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\RGraph\libraries\RGraph.common.tooltips.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\RGraph\libraries\RGraph.pie.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\RGraph\license.txt">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\template_test_util_test.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\Tools.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\OpenCppCoverage.exe">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\template_test_util_test.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="Resources\Package.ico" />
-    <Content Include="OpenCppCoverage-x86\Template\MainTemplate.html">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\SourceTemplate.html">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\css\style.css">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\css\table-images\botleft.png">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\css\table-images\botright.png">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\css\table-images\left.png">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\css\table-images\right.png">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\google-code-prettify\prettify-CppCoverage.css">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\google-code-prettify\prettify.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\google-code-prettify\run_prettify.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\JQuery\jquery-1.11.1.min.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\RGraph\libraries\RGraph.common.core.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\RGraph\libraries\RGraph.common.dynamic.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\RGraph\libraries\RGraph.common.tooltips.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\RGraph\libraries\RGraph.pie.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\RGraph\license.txt">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_chrono-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_date_time-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_filesystem-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_locale-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_log-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_program_options-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_regex-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_system-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_thread-vc140-mt-1_59.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\CppCoverage.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Exporter.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\libctemplate.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\Tools.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
   </ItemGroup>
   <ItemGroup>
     <Page Include="CoverageTree\CoverageTreeControl.xaml">
@@ -493,6 +314,13 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\Fody.1.29.2\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.2\build\dotnet\Fody.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Fody.1.29.2\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.2\build\dotnet\Fody.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/VSPackage/packages.config
+++ b/VSPackage/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="Fody" version="1.29.2" targetFramework="net45" developmentDependency="true" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net45" />
+  <package id="PropertyChanged.Fody" version="1.52.1" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
hi,

i am unable to build the extension, only if copying binaries of opencppcover into some folders this i then possible. probably a better approach is to not include the tool in the extension? feel free not to consider this
