### PR TITLE
run coverage tool from context menu. no need to set startup project

### DIFF
--- a/VSPackage/CoverageRunner.cs
+++ b/VSPackage/CoverageRunner.cs
@@ -60,7 +60,7 @@ namespace OpenCppCoverage.VSPackage
         }
 
         //---------------------------------------------------------------------
-        public void RunCoverageOnStartupProject(MainSettings settings)
+        public void RunCoverageOnCurrentProject(MainSettings settings)
         {
            this.errorHandler.Execute(() =>
            {

--- a/VSPackage/ErrorHandler.cs
+++ b/VSPackage/ErrorHandler.cs
@@ -46,7 +46,7 @@ namespace OpenCppCoverage.VSPackage
             }
             catch (Exception exception)
             {
-                if (OutputWriter != null && OutputWriter.WriteLine(exception.ToString()))             
+                if (OutputWriter != null && OutputWriter.WriteLine(exception.ToString()))
                     ShowMessage("Unknow error. Please see the output console for more information.");
                 else
                     ShowMessage(exception.ToString());

--- a/VSPackage/Guids.cs
+++ b/VSPackage/Guids.cs
@@ -8,7 +8,8 @@ namespace OpenCppCoverage.VSPackage
     {
         public const string guidVSPackagePkgString = "c6a77aca-f53c-4cd1-97d7-0ed595751347";
         public const string guidVSPackageCmdSetString = "fe1f442f-480d-4a2b-bf8a-adc8a0fc569d";
-
+        public const string guidStartCovInProjCTXCmdSetString = "7FFD1AD4-5BFD-4F5C-9EBC-52AFE39D4BFE";
         public static readonly Guid guidVSPackageCmdSet = new Guid(guidVSPackageCmdSetString);
+        public static readonly Guid guidStartCovInProjCTXCmdSet = new Guid(guidStartCovInProjCTXCmdSetString);
     };
 }

--- a/VSPackage/PkgCmdID.cs
+++ b/VSPackage/PkgCmdID.cs
@@ -8,6 +8,6 @@ namespace OpenCppCoverage.VSPackage
     {
         public const uint RunOpenCppCoverageCommand =        0x100;
 
-
+        public const uint RunCoverageInProjectFromProjectCtx = 0x300;
     };
 }

--- a/VSPackage/Settings/IStartUpProjectSettingsBuilder.cs
+++ b/VSPackage/Settings/IStartUpProjectSettingsBuilder.cs
@@ -19,5 +19,6 @@ namespace OpenCppCoverage.VSPackage.Settings
     interface IStartUpProjectSettingsBuilder
     {
         StartUpProjectSettings ComputeSettings();
+        StartUpProjectSettings ComputeSettingsFromSelectedProject();
     }
 }

--- a/VSPackage/Settings/UI/MainSettingController.cs
+++ b/VSPackage/Settings/UI/MainSettingController.cs
@@ -59,6 +59,19 @@ namespace OpenCppCoverage.VSPackage.Settings.UI
             this.MiscellaneousSettingController.UpdateStartUpProject();
         }
 
+        internal void UpdateFromSelectedProjects()
+        {
+            if (this.StartUpProjectSettingsBuilder == null)
+                throw new InvalidOperationException("StartUpProjectSettingsBuilder should be set.");
+
+            var settings = this.StartUpProjectSettingsBuilder.ComputeSettingsFromSelectedProject();
+            this.BasicSettingController.UpdateStartUpProject(settings);
+            this.FilterSettingController.UpdateStartUpProject();
+            this.ImportExportSettingController.UpdateStartUpProject();
+            this.MiscellaneousSettingController.UpdateStartUpProject();
+
+        }
+
         //---------------------------------------------------------------------
         public MainSettings GetMainSettings()
         {
@@ -97,9 +110,9 @@ namespace OpenCppCoverage.VSPackage.Settings.UI
             }
         }
         //---------------------------------------------------------------------
-        void OnRunCoverageCommand()
+        public void OnRunCoverageCommand()
         {
-            this.CoverageRunner.RunCoverageOnStartupProject(this.GetMainSettings());
+            this.CoverageRunner.RunCoverageOnCurrentProject(this.GetMainSettings());
         }
 
         //---------------------------------------------------------------------
@@ -107,5 +120,7 @@ namespace OpenCppCoverage.VSPackage.Settings.UI
         public ICommand RunCoverageCommand { get; private set; }
         public ICommand CancelCommand { get; private set; }
         public ICommand ResetToDefaultCommand { get; private set; }
+
+
     }
 }

--- a/VSPackage/VSPackage.vsct
+++ b/VSPackage/VSPackage.vsct
@@ -70,6 +70,13 @@
       </Button>
 
 
+        <Button guid="guidStartCovInProjCTXCmdSet" id="RunCoverageInProjectFromProjectCtx" priority="0x0300" type="Button">
+            <Parent guid="guidReferenceContext" id="cmdAddReferenceGroup" />
+            <Strings>
+                <CommandName>cmdRunCoverageFromProjectCtx</CommandName>
+                <ButtonText>Run OpenCppCoverage</ButtonText>
+            </Strings>
+        </Button>
 
     </Buttons>
    
@@ -86,6 +93,14 @@
  
   </Commands>
 
+    <!-- Commands in solution explorer -->
+    <CommandPlacements>
+        <CommandPlacement guid="guidStartCovInProjCTXCmdSet" id="RunCoverageInProjectFromProjectCtx" priority="0xF101">
+            <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_BUILD" />
+        </CommandPlacement>
+
+    </CommandPlacements>
+    
 
   <KeyBindings>
     <KeyBinding guid="guidVSPackageCmdSet" id="RunOpenCppCoverageCommand" editor="guidVSStd97" key1="R" mod1="CONTROL" key2="C" mod2="CONTROL"/>
@@ -102,12 +117,18 @@
       <IDSymbol name="MyMenuGroup" value="0x1020" />
       <IDSymbol name="RunOpenCppCoverageCommand" value="0x0100" />
     </GuidSymbol>
-    
-    
+
+      <GuidSymbol name="guidStartCovInProjCTXCmdSet" value="{7FFD1AD4-5BFD-4F5C-9EBC-52AFE39D4BFE}">
+          <IDSymbol name="RunCoverageInProjectFromProjectCtx" value="0x0300" />
+      </GuidSymbol>
     
     <GuidSymbol name="guidImages" value="{b85a417d-6d03-47ea-8445-f6cf164bcc58}" >
       <IDSymbol name="bmpPic1" value="1" />      
     </GuidSymbol>
+
+      <GuidSymbol name="guidReferenceContext" value="{C59571BD-7D8F-4B2E-B1B1-E32918CA4C89}">
+          <IdSymbol name="cmdAddReferenceGroup" value="0x450" />
+      </GuidSymbol>
   </Symbols>
 
 </CommandTable>


### PR DESCRIPTION
hi,

maybe you can consider this enhacemnte 

miss this functionality, right click on a project and collect coverate without the need to setting startup project
