### PR TITLE
Fixed crash, when *.props file is not available.

### DIFF
--- a/VSPackage/DynamicVCProject.cs
+++ b/VSPackage/DynamicVCProject.cs
@@ -33,8 +33,16 @@ namespace OpenCppCoverage.VSPackage
             {
                 var configurations = new List<DynamicVCConfiguration>();
                 foreach (var configuration in project_.Configurations)
-                    configurations.Add(new DynamicVCConfiguration(configuration));
-
+                {
+                    try
+                    {
+                        configurations.Add(new DynamicVCConfiguration(configuration));
+                    }
+                    catch (System.Exception /*exception*/)
+                    {
+                        // skip failed configuration
+                    }
+                }
                 return configurations;
             }
         }


### PR DESCRIPTION
Added try-catch block to handle crash, if project config contains
*.props file which does not exist.
P.S.
I've tried to fix it in easy and obvious way in order to be able to use plugin.
@OpenCppCoverage  perhaps you have better idea how to handle this case.