### PR TITLE
for VisualStudio2022

### DIFF
--- a/CppCoveragePlugin.sln
+++ b/CppCoveragePlugin.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29009.5
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2D036BFA-5FAC-467B-9648-5B2BBC5B872C}"
 	ProjectSection(SolutionItems) = preProject
@@ -36,5 +36,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1E333D91-8EDB-46BF-8025-24EB9E8DF2EC}
 	EndGlobalSection
 EndGlobal

--- a/CppCoveragePlugin.sln
+++ b/CppCoveragePlugin.sln
@@ -5,8 +5,7 @@ VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2D036BFA-5FAC-467B-9648-5B2BBC5B872C}"
 	ProjectSection(SolutionItems) = preProject
-		IntegrationTests.testsettings = IntegrationTests.testsettings
-		UnitTests.testsettings = UnitTests.testsettings
+		UnitTests.runsettings = UnitTests.runsettings
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSPackage", "VSPackage\VSPackage.csproj", "{DF742CAB-0446-4867-A437-719390CC028A}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![](https://github.com/OpenCppCoverage/OpenCppCoveragePlugin/workflows/Unit%20tests/badge.svg)
-# OpenCppCoveragePlugin
-Official Visual Studio Plugin for OpenCppCoverage
+# OpenCppCoveragePlugin for VisualStudio2022
+This is a fork of [Official Visual Studio Plugin for OpenCppCoverage](https://github.com/OpenCppCoverage/OpenCppCoveragePlugin).
+This works for me. But tests are broken.
 
 **OpenCppCoverage** is an open source code coverage tool for C++ under Windows. You can find more information about this project [here](https://opencppcoverage.codeplex.com/).
 
@@ -8,54 +9,68 @@ This repository contains only the Visual Studio plugin sources.
 
 ## Usage
 
-To install and use this plugin, please see the [Visual Studio Gallery page](https://visualstudiogallery.msdn.microsoft.com/f45b8e13-f847-4b3b-92df-984df633b60e).
-You can also install the NuGet package **OpenCppCoverage Plugin**.
+~~To install and use this plugin, please see the [Visual Studio Gallery page](https://visualstudiogallery.msdn.microsoft.com/f45b8e13-f847-4b3b-92df-984df633b60e).
+You can also install the NuGet package **OpenCppCoverage Plugin**.~~
 
 **Documentation is available [here](https://github.com/OpenCppCoverage/OpenCppCoveragePlugin/wiki)**.
 
-For questions, you can create a discussion [here](https://opencppcoverage.codeplex.com/discussions).
-If you find a bug, you can create an issue [here](https://opencppcoverage.codeplex.com/workitem/list/basic).
+~~For questions, you can create a discussion [here](https://opencppcoverage.codeplex.com/discussions).
+If you find a bug, you can create an issue [here](https://opencppcoverage.codeplex.com/workitem/list/basic).~~
 
 ## Development
 
 ### Compilation
-You have 2 Visual Studio solution files but **Visual Studio 2017 is always required**.
-Please also make sure you have Visual Studio 2017 **version 15.8.X**.
+You have 2 Visual Studio solution files but **Visual Studio 2022 is always required**.
+Please also make sure you have Visual Studio 2022 **version 17.3.X**.
 
 #### CppCoveragePlugin.sln
-This is the default solution file and it requires only Visual Studio 2017.
+This is the default solution file and it requires only Visual Studio 2022.
 
 #### CppCoveragePluginVS2013.sln
-**This is a Visual Studio 2017 solution file** but it also requires:
- * Visual Studio 2013 Update 5.
- * [Microsoft Visual Studio 2013 SDK](https://visualstudiogallery.msdn.microsoft.com/842766ba-1f32-40cf-8617-39365ebfc134/view/). If you have any trouble to install the SDK, [this stack overflow question](https://stackoverflow.com/questions/22949411/visual-studio-2012-install-fails-program-compatibility-mode-is-on/23114542) can help.
- * Visual Studio 2015 Update 3 may be required.
+~~**This is a Visual Studio 2017 solution file** but it also requires:~~
+ * ~~Visual Studio 2013 Update 5.~~
+ * ~~[Microsoft Visual Studio 2013 SDK](https://visualstudiogallery.msdn.microsoft.com/842766ba-1f32-40cf-8617-39365ebfc134/view/). If you have any trouble to install the SDK, [this stack overflow question](https://stackoverflow.com/questions/22949411/visual-studio-2012-install-fails-program-compatibility-mode-is-on/23114542) can help.~~
+ * ~~Visual Studio 2015 Update 3 may be required.~~
  
-This solution should be used only to generate a plugin compatible with Visual Studio 2013, 2015 and 2017.
+~~This solution should be used only to generate a plugin compatible with Visual Studio 2013, 2015 and 2017.~~
 
 #### OpenCppCoverage
-You should install the latest version of [OpenCppCoverage](https://github.com/OpenCppCoverage/OpenCppCoverage/releases/tag/release-0.9.7.0):
+You should install the latest version of [OpenCppCoverage](https://github.com/OpenCppCoverage/OpenCppCoverage/releases/tag/release-0.9.9.0):
 * *OpenCppCoverageSetup-x64-X.X.X.exe*: into *VSPackage\OpenCppCoverage-x64* 
 * *OpenCppCoverageSetup-x86-X.X.X.exe*: into *VSPackage\OpenCppCoverage-x86*
 
 You can also copy past the binaries from an existing installation into these folders.
 Binaries inside *VSPackage\OpenCppCoverage-x86* can be the same as *VSPackage\OpenCppCoverage-x64* (The opposite is not true).  
 
+You also should copy msvcp140.dll and vcruntime140.dll from  
+`C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE`
+to 
+`\your\solution\directory\VSPackage\OpenCppCoverage-x64` and
+`\your\solution\directory\VSPackage\OpenCppCoverage-x86`.
+
+You also should copy Newtonsoft.Json.dll from 
+`C:\Users\YourName\.nuget\packages\newtonsoft.json\13.0.1\lib\net45`
+to 
+`\your\solution\directory\VSPackage\`.
+
 ### Run the plugin
 
 * Set *VSPackage* as *StartUp Project*.
 * In *VSPackage Properties*, tab *Debug*:
-  * Select *Start external program* and set value to `C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\devenv.exe` (Update this path if you installed Visual Studio to another location).
+  * Select *Start external program* and set value to `C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\devenv.exe` (Update this path if you installed Visual Studio to another location).
   * Add `/RootSuffix Exp` as *Command line arguments*.
 
 If you have an issue when running the plugin, you can try to reset Visual Studio Experimental instance:
 
-`"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VSSDK\VisualStudioIntegration\Tools\Bin\CreateExpInstance.exe" /Reset /VSInstance=15.0 /RootSuffix=Exp`
+`"C:\Program Files\Microsoft Visual Studio\2022\Communityy\VSSDK\VisualStudioIntegration\Tools\Bin\CreateExpInstance.exe" /Reset /VSInstance=17.0 /RootSuffix=Exp`
 
 ### Run unit tests
 
 You can run the tests with *Test Explorer window*.
-To run *VSPackage_IntegrationTests* you need to expand *Solution items* in *Solution Explorer* and set *Active Load and Web Test Settings* for *IntegrationTests.testsettings*. If you have a COM error when running tests, you can select *IntegrationTests.testsettings* file from Visual Studio menu: Test/Test Settings/Select Test Settings File.
-For *VSPackage_UnitTests* you need to do the same but with *UnitTests.testsettings*.
+~~To run *VSPackage_IntegrationTests* you need to expand *Solution items* in *Solution Explorer* and set *Active Load and Web Test Settings* for *IntegrationTests.testsettings*. If you have a COM error when running tests, you can select *IntegrationTests.testsettings* file from Visual Studio menu: Test/Test Settings/Select Test Settings File.~~
+
+On Visual Studio 2022 *VSPackage_IntegrationTests* is broken because VSIDETestAdapter is deprecated and already erased.
+
+For *VSPackage_UnitTests* you need to do with *UnitTests.runsettings*.
 
 If a test failed, you can try to run it again. You can also reset Visual Studio Experimental instance.

--- a/UnitTests.runsettings
+++ b/UnitTests.runsettings
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+	<!-- Configurations that affect the Test Framework -->
+	<RunConfiguration>
+		<!-- Use 0 for maximum process-level parallelization. This does not force parallelization within the test DLL (on the thread-level). You can also change it from the Test menu; choose "Run tests in parallel". Unchecked = 1 (only 1), checked = 0 (max). -->
+		<MaxCpuCount>1</MaxCpuCount>
+		<!-- Path relative to directory that contains .runsettings file-->
+		<ResultsDirectory>.\TestResults</ResultsDirectory>
+
+		<!-- Omit the whole tag for auto-detection. -->
+		<!-- [x86] or x64, ARM, ARM64, s390x  -->
+		<!-- You can also change it from the Test menu; choose "Processor Architecture for AnyCPU Projects" -->
+		<TargetPlatform>x64</TargetPlatform>
+
+		<!-- Any TargetFramework moniker or omit the whole tag for auto-detection. -->
+		<!-- net48, [net40], net6.0, net5.0, netcoreapp3.1, uap10.0 etc. -->
+		<TargetFrameworkVersion>net472</TargetFrameworkVersion>
+
+		<!-- Path to Test Adapters -->
+		<TestAdaptersPaths>.</TestAdaptersPaths>
+
+		<!-- TestSessionTimeout was introduced in Visual Studio 2017 version 15.5 -->
+		<!-- Specify timeout in milliseconds. A valid value should be greater than 0 -->
+		<TestSessionTimeout>500000</TestSessionTimeout>
+
+		<!-- true or false -->
+		<!-- Value that specifies the exit code when no tests are discovered -->
+		<TreatNoTestsAsError>true</TreatNoTestsAsError>
+	</RunConfiguration>
+
+	<!-- Configurations for data collectors -->
+	<DataCollectionRunSettings>
+		<DataCollectors>
+			<DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+				<Configuration>
+					<CodeCoverage>
+						<ModulePaths>
+							<Exclude>
+								<ModulePath>.*CPPUnitTestFramework.*</ModulePath>
+							</Exclude>
+						</ModulePaths>
+
+						<!-- We recommend you do not change the following values: -->
+						<UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
+						<AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
+						<CollectFromChildProcesses>True</CollectFromChildProcesses>
+						<CollectAspDotNet>False</CollectAspDotNet>
+
+					</CodeCoverage>
+				</Configuration>
+			</DataCollector>
+
+			<DataCollector uri="datacollector://microsoft/VideoRecorder/1.0" assemblyQualifiedName="Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorder.VideoRecorderDataCollector, Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorder, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" friendlyName="Screen and Voice Recorder">
+				<!--Video data collector was introduced in Visual Studio 2017 version 15.5 -->
+				<Configuration>
+					<!-- Set "sendRecordedMediaForPassedTestCase" to "false" to add video attachments to failed tests only -->
+					<MediaRecorder sendRecordedMediaForPassedTestCase="true"  xmlns="">
+						​
+						<ScreenCaptureVideo bitRate="512" frameRate="2" quality="20" />​
+					</MediaRecorder>​
+				</Configuration>
+			</DataCollector>
+
+			<!-- Configuration for blame data collector -->
+			<DataCollector friendlyName="blame" enabled="True">
+			</DataCollector>
+
+		</DataCollectors>
+	</DataCollectionRunSettings>
+
+	<!-- Parameters used by tests at run time -->
+	<TestRunParameters>
+		<Parameter name="webAppUrl" value="http://localhost" />
+		<Parameter name="webAppUserName" value="Admin" />
+		<Parameter name="webAppPassword" value="Password" />
+	</TestRunParameters>
+
+	<!-- Configuration for loggers -->
+	<LoggerRunSettings>
+		<Loggers>
+			<Logger friendlyName="console" enabled="True">
+				<Configuration>
+					<Verbosity>quiet</Verbosity>
+				</Configuration>
+			</Logger>
+			<Logger friendlyName="trx" enabled="True">
+				<Configuration>
+					<LogFileName>foo.trx</LogFileName>
+				</Configuration>
+			</Logger>
+			<Logger friendlyName="html" enabled="True">
+				<Configuration>
+					<LogFileName>foo.html</LogFileName>
+				</Configuration>
+			</Logger>
+			<Logger friendlyName="blame" enabled="True" />
+		</Loggers>
+	</LoggerRunSettings>
+
+	<!-- Adapter Specific sections -->
+
+	<!-- MSTest adapter -->
+	<MSTest>
+		<MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+		<CaptureTraceOutput>false</CaptureTraceOutput>
+		<DeleteDeploymentDirectoryAfterTestRunIsComplete>False</DeleteDeploymentDirectoryAfterTestRunIsComplete>
+		<DeploymentEnabled>False</DeploymentEnabled>
+		<AssemblyResolution>
+			<Directory path="D:\myfolder\bin\" includeSubDirectories="false"/>
+		</AssemblyResolution>
+	</MSTest>
+
+</RunSettings>

--- a/VSPackage/VSPackage.csproj
+++ b/VSPackage/VSPackage.csproj
@@ -280,27 +280,15 @@
     <Content Include="Newtonsoft.Json.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="OpenCppCoverage-x64\boost_date_time-vc141-mt-x64-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_filesystem-vc141-mt-x64-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
+    <Content Include="OpenCppCoverage-x64\boost_date_time-vc142-mt-x64-1_72.dll" />
+    <Content Include="OpenCppCoverage-x64\boost_filesystem-vc142-mt-x64-1_72.dll" />
     <Content Include="OpenCppCoverage-x64\boost_iostreams.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="OpenCppCoverage-x64\boost_locale-vc141-mt-x64-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_log-vc141-mt-x64-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_program_options-vc141-mt-x64-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x64\boost_thread-vc141-mt-x64-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
+    <Content Include="OpenCppCoverage-x64\boost_locale-vc142-mt-x64-1_72.dll" />
+    <Content Include="OpenCppCoverage-x64\boost_log-vc142-mt-x64-1_72.dll" />
+    <Content Include="OpenCppCoverage-x64\boost_program_options-vc142-mt-x64-1_72.dll" />
+    <Content Include="OpenCppCoverage-x64\boost_thread-vc142-mt-x64-1_72.dll" />
     <Content Include="OpenCppCoverage-x64\bz2.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -367,9 +355,7 @@
     <Content Include="OpenCppCoverage-x64\Template\third-party\google-code-prettify\run_prettify.js">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="OpenCppCoverage-x64\Template\third-party\JQuery\jquery-1.11.1.min.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
+    <Content Include="OpenCppCoverage-x64\Template\third-party\JQuery\jquery-3.4.1.min.js" />
     <Content Include="OpenCppCoverage-x64\Template\third-party\RGraph\libraries\RGraph.common.core.js">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -397,9 +383,15 @@
     <Content Include="OpenCppCoverage-x64\zstd.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="OpenCppCoverage-x86\boost_date_time-vc142-mt-x32-1_72.dll" />
+    <Content Include="OpenCppCoverage-x86\boost_filesystem-vc142-mt-x32-1_72.dll" />
     <Content Include="OpenCppCoverage-x86\boost_iostreams.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="OpenCppCoverage-x86\boost_locale-vc142-mt-x32-1_72.dll" />
+    <Content Include="OpenCppCoverage-x86\boost_log-vc142-mt-x32-1_72.dll" />
+    <Content Include="OpenCppCoverage-x86\boost_program_options-vc142-mt-x32-1_72.dll" />
+    <Content Include="OpenCppCoverage-x86\boost_thread-vc142-mt-x32-1_72.dll" />
     <Content Include="OpenCppCoverage-x86\bz2.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -427,6 +419,7 @@
     <Content Include="OpenCppCoverage-x86\Plugins\Exporter\ForceFolderCreation.txt">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="OpenCppCoverage-x86\Template\third-party\JQuery\jquery-3.4.1.min.js" />
     <Content Include="OpenCppCoverage-x86\vcruntime140.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -467,9 +460,6 @@
     <Content Include="OpenCppCoverage-x86\Template\third-party\google-code-prettify\run_prettify.js">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="OpenCppCoverage-x86\Template\third-party\JQuery\jquery-1.11.1.min.js">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="OpenCppCoverage-x86\Template\third-party\RGraph\libraries\RGraph.common.core.js">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -483,24 +473,6 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="OpenCppCoverage-x86\Template\third-party\RGraph\license.txt">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_date_time-vc141-mt-x32-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_filesystem-vc141-mt-x32-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_locale-vc141-mt-x32-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_log-vc141-mt-x32-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_program_options-vc141-mt-x32-1_69.dll">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="OpenCppCoverage-x86\boost_thread-vc141-mt-x32-1_69.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="OpenCppCoverage-x86\CppCoverage.dll">

--- a/VSPackage/VSPackage.csproj
+++ b/VSPackage/VSPackage.csproj
@@ -243,7 +243,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="CoverageData\CoverageData.proto" />
-    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -550,6 +549,20 @@
       <ProductName>.NET Framework 3.5 SP1</ProductName>
       <Install>false</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CommonServiceLocator">
+      <Version>1.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="Google.ProtocolBuffers">
+      <Version>2.4.1.555</Version>
+    </PackageReference>
+    <PackageReference Include="MvvmLightLibs">
+      <Version>5.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>6.0.8</Version>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <UseCodebase>true</UseCodebase>

--- a/VSPackage/VSPackage.csproj
+++ b/VSPackage/VSPackage.csproj
@@ -65,7 +65,6 @@
       <HintPath>..\Externals\ICSharpCode.TreeView.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationFramework.Aero" />

--- a/VSPackage/VSPackage.csproj
+++ b/VSPackage/VSPackage.csproj
@@ -520,7 +520,7 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup>
-    <PreBuildEvent>"$(SolutionDir)packages\Google.ProtocolBuffers.2.4.1.555\tools\ProtoGen.exe" --proto_path="$(SolutionDir)VSPackage\CoverageData" -namespace=OpenCppCoverage.VSPackage.CoverageData.ProtoBuff -output_directory="$(ProjectDir)CoverageData" CoverageData.proto
+    <PreBuildEvent>%25USERPROFILE%25"\.nuget\packages\google.protocolbuffers\2.4.1.555\tools\ProtoGen.exe" --proto_path="$(SolutionDir)VSPackage\CoverageData" -namespace=OpenCppCoverage.VSPackage.CoverageData.ProtoBuff -output_directory="$(ProjectDir)CoverageData" CoverageData.proto
 
 for /f "usebackq tokens=*" %25%25i in (`"%25ProgramFiles(x86)%25\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find VSSDK\VisualStudioIntegration\Tools\Bin\VsixColorCompiler.exe`) do (
    "%25%25i" "$(ProjectDir)\Themes.xml" "$(ProjectDir)\Themes.pkgdef" /noLogo

--- a/VSPackage/VSPackage.csproj
+++ b/VSPackage/VSPackage.csproj
@@ -60,12 +60,6 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
     <Reference Include="GalaSoft.MvvmLight, Version=5.3.0.19026, Culture=neutral, PublicKeyToken=e7570ab207bcb616, processorArchitecture=MSIL">
       <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.dll</HintPath>
       <Private>True</Private>
@@ -556,6 +550,9 @@
     </PackageReference>
     <PackageReference Include="Google.ProtocolBuffers">
       <Version>2.4.1.555</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK">
+      <Version>17.3.32804.24</Version>
     </PackageReference>
     <PackageReference Include="MvvmLightLibs">
       <Version>5.3.0</Version>

--- a/VSPackage/VSPackage.csproj
+++ b/VSPackage/VSPackage.csproj
@@ -60,60 +60,12 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GalaSoft.MvvmLight, Version=5.3.0.19026, Culture=neutral, PublicKeyToken=e7570ab207bcb616, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="GalaSoft.MvvmLight.Extras, Version=5.3.0.19032, Culture=neutral, PublicKeyToken=669f0b5e8f868abf, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.Extras.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="GalaSoft.MvvmLight.Platform, Version=5.3.0.19032, Culture=neutral, PublicKeyToken=5f873c45e98af8a1, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.Platform.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
-    </Reference>
     <Reference Include="ICSharpCode.TreeView, Version=5.0.0.0, Culture=neutral, PublicKeyToken=f829da5c02be14ee, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Externals\ICSharpCode.TreeView.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.CommandBars, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=16.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Utilities, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationFramework.Aero" />
@@ -125,10 +77,6 @@
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmLightLibs.5.3.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
@@ -554,11 +502,16 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK">
       <Version>17.3.32804.24</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools">
+      <Version>17.4.2118</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="MvvmLightLibs">
       <Version>5.3.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>6.0.8</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/VSPackage/packages.config
+++ b/VSPackage/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
-  <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
-  <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-</packages>

--- a/VSPackage/source.extension.vsixmanifest
+++ b/VSPackage/source.extension.vsixmanifest
@@ -13,6 +13,12 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[12.0]" />
         <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
         <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/VSPackage_IntegrationTests/VSPackage_IntegrationTests.csproj
+++ b/VSPackage_IntegrationTests/VSPackage_IntegrationTests.csproj
@@ -38,8 +38,6 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="envdte" />
-    <Reference Include="envdte80" />
     <Reference Include="ICSharpCode.TreeView">
       <HintPath>..\Externals\ICSharpCode.TreeView.dll</HintPath>
     </Reference>
@@ -96,6 +94,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.SDK">
+      <Version>17.3.32804.24</Version>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>

--- a/VSPackage_IntegrationTests/VSPackage_IntegrationTests.csproj
+++ b/VSPackage_IntegrationTests/VSPackage_IntegrationTests.csproj
@@ -88,7 +88,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Key.snk" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VSPackage\VSPackage.csproj">
@@ -96,7 +95,11 @@
       <Name>VSPackage</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>Echo Update "$(TargetDir)"

--- a/VSPackage_IntegrationTests/VSPackage_IntegrationTests.csproj
+++ b/VSPackage_IntegrationTests/VSPackage_IntegrationTests.csproj
@@ -42,26 +42,8 @@
       <HintPath>..\Externals\ICSharpCode.TreeView.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Editor, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VSSDK.TestHostFramework, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.VSSDK.TestHostFramework, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -97,8 +79,13 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK">
       <Version>17.3.32804.24</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools">
+      <Version>17.4.2118</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/VSPackage_IntegrationTests/packages.config
+++ b/VSPackage_IntegrationTests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-</packages>

--- a/VSPackage_UnitTests/VSPackage_UnitTests.csproj
+++ b/VSPackage_UnitTests/VSPackage_UnitTests.csproj
@@ -42,30 +42,12 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
-    </Reference>
     <Reference Include="ICSharpCode.TreeView">
       <HintPath>..\Externals\ICSharpCode.TreeView.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VSSDK.TestHostFramework, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VSSDK.TestHostFramework, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <!---->
-    <Reference Include="Moq, Version=4.5.9.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.5.9\lib\net45\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -113,11 +95,16 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK">
       <Version>17.3.32804.24</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools">
+      <Version>17.4.2118</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.5.9</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="OpenCover">
       <Version>4.7.922</Version>

--- a/VSPackage_UnitTests/VSPackage_UnitTests.csproj
+++ b/VSPackage_UnitTests/VSPackage_UnitTests.csproj
@@ -46,12 +46,6 @@
       <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
@@ -115,6 +109,9 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core">
       <Version>3.3.3</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK">
+      <Version>17.3.32804.24</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.5.9</Version>

--- a/VSPackage_UnitTests/VSPackage_UnitTests.csproj
+++ b/VSPackage_UnitTests/VSPackage_UnitTests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
-  <Import Project="..\packages\ReportGenerator.4.3.2\build\netstandard2.0\ReportGenerator.props" Condition="Exists('..\packages\ReportGenerator.4.3.2\build\netstandard2.0\ReportGenerator.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -84,7 +83,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Key.snk" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VSPackage\VSPackage.csproj">
@@ -114,11 +112,22 @@
     <Compile Include="TestHelper.cs" />
     <Compile Include="TreeNodeVisibilityManagerTests.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Castle.Core">
+      <Version>3.3.3</Version>
+    </PackageReference>
+    <PackageReference Include="Moq">
+      <Version>4.5.9</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.3</Version>
+    </PackageReference>
+    <PackageReference Include="OpenCover">
+      <Version>4.7.922</Version>
+    </PackageReference>
+    <PackageReference Include="ReportGenerator">
+      <Version>4.3.2</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\ReportGenerator.4.3.2\build\netstandard2.0\ReportGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReportGenerator.4.3.2\build\netstandard2.0\ReportGenerator.props'))" />
-  </Target>
 </Project>

--- a/VSPackage_UnitTests/packages.config
+++ b/VSPackage_UnitTests/packages.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="Moq" version="4.5.9" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="OpenCover" version="4.7.922" targetFramework="net472" />
-  <package id="ReportGenerator" version="4.3.2" targetFramework="net472" />
-</packages>


### PR DESCRIPTION
Thank you for your request!

https://github.com/OpenCppCoverage/OpenCppCoveragePlugin/issues/48#issuecomment-1609010483

```
This works for me.
https://github.com/h1day/OpenCppCoveragePlugin/releases/tag/for-vs2022

But integration test is broken.
Because VSIDETestAdapter is deprecated and already erased.
I couldn't fix it.
```